### PR TITLE
duplicate argument; unlikely fix: add command as finish argument as well

### DIFF
--- a/io.gitlab.librewolf-community.json
+++ b/io.gitlab.librewolf-community.json
@@ -35,7 +35,7 @@
         "--env=MOZ_USE_XINPUT2=1",
         "--own-name=io.gitlab.librewolf.*",
         "--own-name=org.mpris.MediaPlayer2.firefox.*",
-        "--share=network"
+        "--command=librewolf"
     ],
     "modules": [
         "shared-modules/dbus-glib/dbus-glib-0.110.json",


### PR DESCRIPTION
=> unlikely to fix the current issue of settings not applying, but worth a try – if only for triggering a test (re-)build.
should that not do anything, we might hope things will _magically_ get fixed with 108.0.1? :/