### PR TITLE
Harden Permission

### DIFF
--- a/io.gitlab.librewolf-community.json
+++ b/io.gitlab.librewolf-community.json
@@ -20,7 +20,7 @@
         "--socket=pulseaudio",
         "--socket=cups",
         "--persist=.librewolf",
-        "--filesystem=xdg-download:rw",
+        "--persist=.mozilla",
         "--filesystem=xdg-run/pipewire-0",
         "--device=dri",
         "--talk-name=org.freedesktop.FileManager1",


### PR DESCRIPTION
- remove download file permission to use file chooser portal instead
- move `.mozilla` folder to app sandbox from the user home folder, by adding it as a persistent folder.