### PR TITLE
Allow UPower access through the system message bus

### DIFF
--- a/io.gitlab.librewolf-community.json
+++ b/io.gitlab.librewolf-community.json
@@ -25,6 +25,7 @@
         "--device=dri",
         "--talk-name=org.freedesktop.FileManager1",
         "--system-talk-name=org.freedesktop.NetworkManager",
+        "--system-talk-name=org.freedesktop.UPower",
         "--talk-name=org.a11y.Bus",
         "--talk-name=org.gnome.SessionManager",
         "--talk-name=org.freedesktop.ScreenSaver",


### PR DESCRIPTION
This silences a LibreWolf warning triggered by loading some websites.

Fixes #126