### PR TITLE
Update runtime and ffmpeg-full extension to 24.08

### DIFF
--- a/io.gitlab.librewolf-community.json
+++ b/io.gitlab.librewolf-community.json
@@ -1,12 +1,12 @@
 {
     "app-id": "io.gitlab.librewolf-community",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
-            "version": "23.08",
+            "version": "24.08",
             "add-ld-path": "."
         }
     },


### PR DESCRIPTION
And also update the `shared-modules` submodule.

I've been running LibreWolf under the 24.08 runtime for a few days and so far I haven't found any issues.