### PR TITLE
chore: remove pipewire-0 filesystem permission

### DIFF
--- a/io.gitlab.librewolf-community.json
+++ b/io.gitlab.librewolf-community.json
@@ -21,7 +21,6 @@
         "--socket=cups",
         "--persist=.librewolf",
         "--filesystem=xdg-download:rw",
-        "--filesystem=xdg-run/pipewire-0",
         "--filesystem=xdg-run/speech-dispatcher:ro",
         "--device=dri",
         "--talk-name=org.freedesktop.FileManager1",


### PR DESCRIPTION
This is no longer required per
https://hg.mozilla.org/mozilla-central/rev/135c35ce2cf771b8bb13428103547c1abd684d5c (thanks @FriedrichGaming)