### PR TITLE
Update action names to match Firefox

### DIFF
--- a/io.gitlab.librewolf-community.desktop
+++ b/io.gitlab.librewolf-community.desktop
@@ -14,13 +14,13 @@ Keywords=Internet;WWW;Browser;Web;Explorer;
 Actions=new-window;new-private-window;profilemanager;
 
 [Desktop Action new-window]
-Name=Open a New Window
+Name=New Window
 Exec=librewolf %u
 
 [Desktop Action new-private-window]
-Name=Open a New Private Window
+Name=New Private Window
 Exec=librewolf --private-window %u
 
 [Desktop Action profilemanager]
-Name=Open the Profile Manager
+Name=Open Profile Manager
 Exec=librewolf --ProfileManager %u


### PR DESCRIPTION
The names for all three actions in Librewolf's desktop file are a bit long. In addition to personal aesthetics, this change is an improvement for the following reasons:
- It brings the names of these actions in line with the Firefox flatpak.
- In general, most actions which create a new window tend to be named exactly "New Window". The "Open a" part is always left out.
- The name matches the default "New Window" action that GNOME creates by default for apps which don't provide a dedicated option.